### PR TITLE
Infrac: check rank before infracting

### DIFF
--- a/starbot/modules/moderation/_constants.py
+++ b/starbot/modules/moderation/_constants.py
@@ -3,6 +3,7 @@ from starbot.models.infraction import InfractionTypes
 INFRACTIONS_WITH_DURATIONS = {InfractionTypes.MUTE}
 HIDDEN_INFRACTIONS = {InfractionTypes.NOTE}
 UNIQUE_INFRACTIONS = {InfractionTypes.MUTE, InfractionTypes.BAN}
+INFRACTION_REQUIRING_RANK = {InfractionTypes.MUTE, InfractionTypes.KICK, InfractionTypes.BAN}
 
 INFRACTION_NAME = {
     InfractionTypes.NOTE: "note",


### PR DESCRIPTION
If the bot has a rank lower than the user infracted, the DM would still be sent but the infraction will fail to apply.
This adds an additional check to prevent that.

Closes #6.